### PR TITLE
BugFix: Fix duplicate public permissions

### DIFF
--- a/server/helpers/setPublicContentTypes.ts
+++ b/server/helpers/setPublicContentTypes.ts
@@ -71,6 +71,15 @@ export async function setPublicContentTypes({
 
     const publicPermissions = await db.getPublicPermissions(trx);
 
+    // Verificar quais permissões da lista toInsert já existem no banco
+    const existingPermissionsToInsert = await db.getPermissionsByActions(
+      trx,
+      toInsert
+    );
+    const existingActionSet = new Set(
+      existingPermissionsToInsert.map((p) => p.action)
+    );
+
     const existingPermissions: UPPermission[] = [];
     const permissionsToDelete: UPPermission[] = [];
     const permissionsToInsert: string[] = [];
@@ -96,8 +105,9 @@ export async function setPublicContentTypes({
       }
     }
 
+    // Filtrar apenas as ações que realmente não existem no banco
     for (const action of toInsert) {
-      if (!existingPermissions.find((p) => p.action === action)) {
+      if (!existingActionSet.has(action)) {
         permissionsToInsert.push(action);
       }
     }

--- a/server/helpers/setPublicContentTypes.ts
+++ b/server/helpers/setPublicContentTypes.ts
@@ -71,7 +71,6 @@ export async function setPublicContentTypes({
 
     const publicPermissions = await db.getPublicPermissions(trx);
 
-    // Verificar quais permissões da lista toInsert já existem no banco
     const existingPermissionsToInsert = await db.getPermissionsByActions(
       trx,
       toInsert
@@ -105,7 +104,6 @@ export async function setPublicContentTypes({
       }
     }
 
-    // Filtrar apenas as ações que realmente não existem no banco
     for (const action of toInsert) {
       if (!existingActionSet.has(action)) {
         permissionsToInsert.push(action);

--- a/server/helpers/setPublicContentTypes.ts
+++ b/server/helpers/setPublicContentTypes.ts
@@ -75,6 +75,7 @@ export async function setPublicContentTypes({
       trx,
       toInsert
     );
+
     const existingActionSet = new Set(
       existingPermissionsToInsert.map((p) => p.action)
     );


### PR DESCRIPTION
## Description  
This PR fixes an issue where permissions were being recreated on every application restart, causing multiple duplicate records in the database.  

## Changes  
- Added validation to prevent recreating existing permissions  
- Ensured the initialization process only inserts new permissions when necessary  

## Expected Behavior  
After this change:  
- Permissions are not duplicated on application restarts  
- The database remains clean and consistent  